### PR TITLE
Use sw-precache-webpack-plugin v0.9.1 for node >=4.0.0 support

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -59,7 +59,7 @@
     "recursive-readdir": "2.1.1",
     "strip-ansi": "3.0.1",
     "style-loader": "0.13.1",
-    "sw-precache-webpack-plugin": "^0.9.0",
+    "sw-precache-webpack-plugin": "^0.9.1",
     "url-loader": "0.5.7",
     "webpack": "2.2.1",
     "webpack-dev-server": "2.4.1",


### PR DESCRIPTION
Use `sw-precache-webpack-plugin` `v0.9.1` because it lowers NodeJS engine requirement to v4.0.0 facebookincubator/create-react-app#1728